### PR TITLE
feat: add contact-us-messages collection

### DIFF
--- a/src/api/contact-us-message/content-types/contact-us-message/schema.json
+++ b/src/api/contact-us-message/content-types/contact-us-message/schema.json
@@ -1,0 +1,25 @@
+{
+  "kind": "collectionType",
+  "collectionName": "contact_us_messages",
+  "info": {
+    "singularName": "contact-us-message",
+    "pluralName": "contact-us-messages",
+    "displayName": "Contact Us Message",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "fullName": {
+      "type": "string"
+    },
+    "email": {
+      "type": "email"
+    },
+    "message": {
+      "type": "text"
+    }
+  }
+}

--- a/src/api/contact-us-message/content-types/contact-us-message/schema.json
+++ b/src/api/contact-us-message/content-types/contact-us-message/schema.json
@@ -12,7 +12,7 @@
   },
   "pluginOptions": {},
   "attributes": {
-    "fullName": {
+    "name": {
       "type": "string"
     },
     "email": {

--- a/src/api/contact-us-message/controllers/contact-us-message.js
+++ b/src/api/contact-us-message/controllers/contact-us-message.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * contact-us-message controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::contact-us-message.contact-us-message');

--- a/src/api/contact-us-message/routes/contact-us-message.js
+++ b/src/api/contact-us-message/routes/contact-us-message.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * contact-us-message router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::contact-us-message.contact-us-message');

--- a/src/api/contact-us-message/services/contact-us-message.js
+++ b/src/api/contact-us-message/services/contact-us-message.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * contact-us-message service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::contact-us-message.contact-us-message');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -732,7 +732,7 @@ export interface ApiContactUsMessageContactUsMessage
     draftAndPublish: true;
   };
   attributes: {
-    fullName: Attribute.String;
+    name: Attribute.String;
     email: Attribute.Email;
     message: Attribute.Text;
     createdAt: Attribute.DateTime;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -719,6 +719,40 @@ export interface ApiAuthorAuthor extends Schema.CollectionType {
   };
 }
 
+export interface ApiContactUsMessageContactUsMessage
+  extends Schema.CollectionType {
+  collectionName: 'contact_us_messages';
+  info: {
+    singularName: 'contact-us-message';
+    pluralName: 'contact-us-messages';
+    displayName: 'Contact Us Message';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    fullName: Attribute.String;
+    email: Attribute.Email;
+    message: Attribute.Text;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::contact-us-message.contact-us-message',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::contact-us-message.contact-us-message',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface ApiJoinNewsletterJoinNewsletter extends Schema.CollectionType {
   collectionName: 'join_newsletters';
   info: {
@@ -949,6 +983,7 @@ declare module '@strapi/types' {
       'plugin::users-permissions.role': PluginUsersPermissionsRole;
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
       'api::author.author': ApiAuthorAuthor;
+      'api::contact-us-message.contact-us-message': ApiContactUsMessageContactUsMessage;
       'api::join-newsletter.join-newsletter': ApiJoinNewsletterJoinNewsletter;
       'api::news-category.news-category': ApiNewsCategoryNewsCategory;
       'api::news-list.news-list': ApiNewsListNewsList;


### PR DESCRIPTION
Adding a collection to manage inbound contact messages via the contact-us page